### PR TITLE
Rename props to make it clearer

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
@@ -9,7 +9,7 @@ import ModalFullscreen from '/imports/ui/components/common/modal/fullscreen/comp
 import SortList from './sort-user-list/component';
 import Styled from './styles';
 import Icon from '/imports/ui/components/common/icon/component';
-import { isImportSharedNotesFromBreakoutRoomsEnabled, isImportPresentationWithAnnotationsFromBreakoutRoomsEnabled, sendInvitationToIncludedModerators } from '/imports/ui/services/features';
+import { isImportSharedNotesFromBreakoutRoomsEnabled, isImportPresentationWithAnnotationsFromBreakoutRoomsEnabled } from '/imports/ui/services/features';
 import { addNewAlert } from '/imports/ui/components/screenreader-alert/service';
 import PresentationUploaderService from '/imports/ui/components/presentation/presentation-uploader/service';
 import { uniqueId } from '/imports/utils/string-utils';
@@ -173,9 +173,9 @@ const intlMessages = defineMessages({
     id: 'app.createBreakoutRoom.movedUserLabel',
     description: 'screen reader alert when users are moved to rooms',
   },
-  includeMods: {
-    id: 'app.createBreakoutRoom.includeModsInBreakouts',
-    description: 'Include moderators on breakouts invitation',
+  sendInvitationToMods: {
+    id: 'app.createBreakoutRoom.sendInvitationToMods',
+    description: 'label for checkbox send invitation to moderators',
   },
 });
 
@@ -234,7 +234,7 @@ class BreakoutRoom extends PureComponent {
     this.setInvitationConfig = this.setInvitationConfig.bind(this);
     this.setRecord = this.setRecord.bind(this);
     this.setCaptureNotes = this.setCaptureNotes.bind(this);
-    this.setIncludeMods = this.setIncludeMods.bind(this);
+    this.setInviteMods = this.setInviteMods.bind(this);
     this.setCaptureSlides = this.setCaptureSlides.bind(this);
     this.blurDurationTime = this.blurDurationTime.bind(this);
     this.removeRoomUsers = this.removeRoomUsers.bind(this);
@@ -257,7 +257,7 @@ class BreakoutRoom extends PureComponent {
       roomNameEmptyIsValid: true,
       record: false,
       captureNotes: false,
-      includeMods: false,
+      inviteMods: false,
       captureSlides: false,
       durationIsValid: true,
       breakoutJoinedUsers: null,
@@ -273,7 +273,7 @@ class BreakoutRoom extends PureComponent {
     const {
       breakoutJoinedUsers, getLastBreakouts, groups, isUpdate,
       allowUserChooseRoomByDefault, captureSharedNotesByDefault,
-      captureWhiteboardByDefault, includeModsByDefault,
+      captureWhiteboardByDefault, inviteModsByDefault,
     } = this.props;
     setPresentationVisibility('none');
     this.setRoomUsers();
@@ -304,7 +304,7 @@ class BreakoutRoom extends PureComponent {
       freeJoin: allowUserChooseRoomByDefault,
       captureSlides: captureWhiteboardByDefault,
       captureNotes: captureSharedNotesByDefault,
-      includeMods: includeModsByDefault,
+      inviteMods: inviteModsByDefault,
     });
 
     const lastBreakouts = getLastBreakouts();
@@ -442,7 +442,7 @@ class BreakoutRoom extends PureComponent {
       numberOfRooms,
       durationTime,
       durationIsValid,
-      includeMods,
+      inviteMods,
     } = this.state;
 
     if ((durationTime || 0) < MIN_BREAKOUT_TIME) {
@@ -485,7 +485,7 @@ class BreakoutRoom extends PureComponent {
       sequence: seq,
     }));
 
-    createBreakoutRoom(rooms, durationTime, record, captureNotes, captureSlides, includeMods);
+    createBreakoutRoom(rooms, durationTime, record, captureNotes, captureSlides, inviteMods);
     Session.set('isUserListOpen', true);
   }
 
@@ -627,8 +627,8 @@ class BreakoutRoom extends PureComponent {
     this.setState({ captureNotes: e.target.checked });
   }
 
-  setIncludeMods(e) {
-    this.setState({ includeMods: e.target.checked });
+  setInviteMods(e) {
+    this.setState({ inviteMods: e.target.checked });
   }
 
   setCaptureSlides(e) {
@@ -1084,7 +1084,7 @@ class BreakoutRoom extends PureComponent {
       record,
       captureNotes,
       captureSlides,
-      includeMods,
+      inviteMods,
     } = this.state;
     return (
       <Styled.CheckBoxesContainer key="breakout-checkboxes">
@@ -1147,16 +1147,16 @@ class BreakoutRoom extends PureComponent {
           ) : null
         }
         {
-            <Styled.FreeJoinLabel htmlFor="sendInvitationToIncludedModeratorsCheckbox" key="send-invitation-to-included-moderators-breakouts">
+            <Styled.FreeJoinLabel htmlFor="sendInvitationToAssignedModeratorsCheckbox" key="send-invitation-to-assigned-moderators-breakouts">
               <Styled.FreeJoinCheckbox
-                id="sendInvitationToIncludedModeratorsCheckbox"
+                id="sendInvitationToAssignedModeratorsCheckbox"
                 type="checkbox"
-                onChange={this.setIncludeMods}
-                checked={includeMods}
-                aria-label={intl.formatMessage(intlMessages.includeMods)}
+                onChange={this.setInviteMods}
+                checked={inviteMods}
+                aria-label={intl.formatMessage(intlMessages.sendInvitationToMods)}
               />
               <span aria-hidden>
-                {intl.formatMessage(intlMessages.includeMods)}
+                {intl.formatMessage(intlMessages.sendInvitationToMods)}
               </span>
             </Styled.FreeJoinLabel>
         }

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/container.jsx
@@ -13,8 +13,8 @@ const CreateBreakoutRoomContainer = (props) => {
                                     && isImportPresentationWithAnnotationsFromBreakoutRoomsEnabled();
   const captureSharedNotesByDefault = METEOR_SETTINGS_APP.breakouts.captureSharedNotesByDefault
                                     && isImportSharedNotesFromBreakoutRoomsEnabled();
-  const includeModsByDefault = METEOR_SETTINGS_APP.breakouts.sendInvitationToIncludedModerators;
-  
+  const inviteModsByDefault = METEOR_SETTINGS_APP.breakouts.sendInvitationToAssignedModeratorsByDefault;
+
   const { amIModerator } = props;
   return (
     amIModerator
@@ -25,7 +25,7 @@ const CreateBreakoutRoomContainer = (props) => {
           allowUserChooseRoomByDefault,
           captureWhiteboardByDefault,
           captureSharedNotesByDefault,
-          includeModsByDefault,
+          inviteModsByDefault,
         }}
       />
     )

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/service.js
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/service.js
@@ -148,14 +148,6 @@ const amIModerator = () => {
   return User.role === ROLE_MODERATOR;
 };
 
-const checkInviteModerators = () => {
-  const BREAKOUTS_CONFIG = Meteor.settings.public.app.breakouts;
-
-  return !(
-    amIModerator() && !BREAKOUTS_CONFIG.sendInvitationToIncludedModerators
-  );
-};
-
 const getBreakoutByUserId = (userId) =>
   Breakouts.find(
     { [`url_${userId}`]: { $exists: true } },
@@ -250,6 +242,5 @@ export default {
   getBreakoutUserWasIn,
   sortUsersByName: UserListService.sortUsersByName,
   isUserInBreakoutRoom,
-  checkInviteModerators,
   setCapturedContentUploading,
 };

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -127,8 +127,8 @@ public:
       allowUserChooseRoomByDefault: false
       captureWhiteboardByDefault: false
       captureSharedNotesByDefault: false
+      sendInvitationToAssignedModeratorsByDefault: false
       breakoutRoomLimit: 16
-      sendInvitationToIncludedModerators: false
     # https://github.com/bigbluebutton/bigbluebutton/pull/10826
     customHeartbeat: false
     showAllAvailableLocales: true

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -1190,7 +1190,7 @@
     "app.createBreakoutRoom.addParticipantLabel": "+ Add participant",
     "app.createBreakoutRoom.freeJoin": "Allow users to choose a breakout room to join",
     "app.createBreakoutRoom.captureNotes": "Capture shared notes when breakout rooms end",
-    "app.createBreakoutRoom.includeModsInBreakouts": "Include moderators on breakouts invitation",
+    "app.createBreakoutRoom.sendInvitationToMods": "Send invitation to assigned moderators",
     "app.createBreakoutRoom.captureSlides": "Capture whiteboard when breakout rooms end",
     "app.createBreakoutRoom.leastOneWarnBreakout": "You must place at least one user in a breakout room.",
     "app.createBreakoutRoom.minimumDurationWarnBreakout": "Minimum duration for a breakout room is {0} minutes.",


### PR DESCRIPTION
- Renames config `sendInvitationToIncludedModerators`  to `sendInvitationToAssignedModeratorsByDefault`.
- Changes checkbox label "Include moderators on breakouts invitation" to "Send invitation to assigned moderators".
- Rename variables in general to make the name more clear to what it really means