### PR TITLE
test: adding flaky flag

### DIFF
--- a/bigbluebutton-tests/playwright/user/user.spec.js
+++ b/bigbluebutton-tests/playwright/user/user.spec.js
@@ -204,7 +204,7 @@ test.describe.parallel('User', () => {
         await lockViewers.lockSeeOtherViewersUserList();
       });
 
-      test('Lock see other viewers annotations', async ({ browser, context, page }) => {
+      test('Lock see other viewers annotations @flaky', async ({ browser, context, page }) => {
         const lockViewers = new LockViewers(browser, context);
         await lockViewers.initPages(page);
         await lockViewers.lockSeeOtherViewersAnnotations();


### PR DESCRIPTION


### What does this PR do?
Adds flaky flag to the failing test "Lock see other viewers annotations" on CI.